### PR TITLE
Update trivy-action to version v0.35.0 to mitigate of the recent CVEs

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -63,7 +63,7 @@ jobs:
             --format '{{ json .SBOM.SPDX }}' > ./${{ matrix.image.name }}-attestations/${{ matrix.image.name }}-sbom.json
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: image
           image-ref: ${{env.REGISTRY}}/${{ env.ORG }}/${{ matrix.image.name }}:v1.0.0


### PR DESCRIPTION
Updates the trivy-action GitHub Action to `v0.35.0` in `./.github/workflows/action.yaml` in light of [recent security incident](https://github.com/aquasecurity/trivy/discussions/10425) with `trivy` and `trivy-action`. 